### PR TITLE
Fix typo, validation rule, comment and test

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -25,7 +25,7 @@ class EventController extends Controller
             'place' => 'required|string|min:3|max:200',
             'location' => 'required|string|min:3|max:200',
             'start' => 'required|date|after:today',
-            'end' => 'required|date|after:start_event',
+            'end' => 'required|date|after:start',
             'image' => 'nullable|image|max:512|mimes:jpg,jpeg,png',
             'image_left_event' => 'nullable|image|max:1024|mimes:jpg,jpeg,png',
             'image_right_event' => 'nullable|image|max:1024|mimes:jpg,jpeg,png',

--- a/app/Http/Controllers/InvitationController.php
+++ b/app/Http/Controllers/InvitationController.php
@@ -109,7 +109,7 @@ class InvitationController extends Controller
                 $img = 'asset/front/default.png';
             endif;
             // set_time_limit(0); // remove a time limit if not in safe mode OR
-            set_time_limit(180); // set the time limit to 120 seconds
+            set_time_limit(180); // set the time limit to 180 seconds
 
             $mail->SMTPDebug  = SMTP::DEBUG_OFF;                        //Enable verbose debug output
             $mail->isSMTP();           

--- a/public/plugin/sweetalert2/src/scss/_core.scss
+++ b/public/plugin/sweetalert2/src/scss/_core.scss
@@ -334,7 +334,7 @@ div:where(.swal2-container) {
   }
 
   .swal2-html-container {
-    z-index: 1; // prevent sucess icon overlapping the content
+    z-index: 1; // prevent success icon overlapping the content
     justify-content: $swal2-html-container-justify-content;
     margin: $swal2-html-container-margin;
     padding: $swal2-html-container-padding;

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -14,6 +14,6 @@ class ExampleTest extends TestCase
     {
         $response = $this->get('/');
 
-        $response->assertStatus(200);
+        $response->assertRedirect('/dashboard');
     }
 }


### PR DESCRIPTION
## Summary
- correct success comment in SweetAlert2 scss
- fix `end` validation rule
- update time limit comment to 180 seconds
- check redirect to dashboard in ExampleTest

## Testing
- `php ./vendor/bin/phpunit tests/Feature/ExampleTest.php` *(fails: php not installed)*