### PR TITLE
Fix event and invitation form value persistence

### DIFF
--- a/resources/views/event/index.blade.php
+++ b/resources/views/event/index.blade.php
@@ -51,14 +51,14 @@
 									</div>
 									<div class="form-group">
 										<label for="">Mulai Acara *</label>
-										<input class="form-control @error('start') is-invalid @enderror" name="start" value="{{ old('location', $event->start_event) }}" type="datetime-local">
+                                        <input class="form-control @error('start') is-invalid @enderror" name="start" value="{{ old('start', $event->start_event) }}" type="datetime-local">
 										@error('start')
 										<small class="text-danger"> {{ $message }} </small>
 										@enderror
 									</div>
 									<div class="form-group">
 										<label for="">Selesai Acara *</label>
-										<input class="form-control @error('end') is-invalid @enderror" name="end" value="{{ old('location', $event->end_event) }}" type="datetime-local">
+                                        <input class="form-control @error('end') is-invalid @enderror" name="end" value="{{ old('end', $event->end_event) }}" type="datetime-local">
 										@error('end')
 										<small class="text-danger"> {{ $message }} </small>
 										@enderror

--- a/resources/views/invitation/create.blade.php
+++ b/resources/views/invitation/create.blade.php
@@ -54,7 +54,7 @@
                       </div>
                       <div class="form-group">
                         <label for="">Nomor Meja</label>
-                        <input class="form-control" name="table_number" value="{{ old('phone') }}" type="text">
+                        <input class="form-control" name="table_number" value="{{ old('table_number') }}" type="text">
                         @error('table_number')
                           <small class="text-danger"> {{ $message }} </small>
                         @enderror


### PR DESCRIPTION
## Summary
- correct `old()` key for table number on invite creation form
- fix incorrect `old()` values for event start and end fields

## Testing
- `php -v` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*